### PR TITLE
resizeMode and resizeMethod passed as props

### DIFF
--- a/CardImage.js
+++ b/CardImage.js
@@ -17,7 +17,7 @@ export default class CardImage extends Component {
     const newStyle = this.props.style || {};
     return (
       <View style={[styles.cardImage, newStyle]} onLayout={(e)=>{this.setState({calc_height: e.nativeEvent.layout.width*9/16});}}>
-        <Image source={this.props.source} resizeMode="stretch" resizeMethod="resize" style={[styles.imageContainer,  {height: this.state.calc_height}]}>
+        <Image source={this.props.source} resizeMode={["stretch", this.props.resizeMode]} resizeMethod={["resize", this.props.resizeMethod]} style={[styles.imageContainer,  {height: this.state.calc_height}]}>
           {this.props.title!==undefined &&
             <Text style={styles.imageTitleText}>{this.props.title}</Text>
           }

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ import { Card, CardTitle, CardContent, CardAction, CardButton, CardImage } from 
 | ------------- |-------------| -----| -----|
 | source | object | The image to be shown, passed to Image's source prop | undefined |
 | style | color | The  style object to be merged with default style | undefined |
+| resizeMode | string | Determines how to resize the image when the frame doesn't match the raw image dimensions | stretch |
+| resizeMethod | string | Resize the image when the image's dimensions differ from the image view's dimensions. | resize |
 
 ## CardAction Component Options
 | Prop        | Type           | Effect  | Default Value |


### PR DESCRIPTION
Hey @SiDevesh 

I have added a more dynamic way of passing resizeMode and resizeMethod to the card image as props instead of hard-coded on the component. I have also updated the docs to reflect this update.

Cheers
Dale