### PR TITLE
Add prop-types library as a separate dependency

### DIFF
--- a/CardAction.js
+++ b/CardAction.js
@@ -27,7 +27,7 @@ export default class CardAction extends Component {
     const newStyle = this.props.style || {};
     let directionStyle = this.props.inColumn===true ? styles.cardActionInColumn : styles.cardActionInRow;
     return (
-      <View style={(this.props.seperator)&&(!this.props.isDark) ? [directionStyle, styles.seperatorAdd, newStyle] : [directionStyle, newStyle]}>
+      <View style={(this.props.separator)&&(!this.props.isDark) ? [directionStyle, styles.separatorAdd, newStyle] : [directionStyle, newStyle]}>
         {this.renderChildren()}
       </View>
     );
@@ -48,7 +48,7 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-start',
     alignSelf: 'stretch'
   },
-  seperatorAdd: {
+  separatorAdd: {
     borderTopColor: '#E9E9E9',
     borderTopWidth: 1
   }

--- a/CardImage.js
+++ b/CardImage.js
@@ -17,7 +17,7 @@ export default class CardImage extends Component {
     const newStyle = this.props.style || {};
     return (
       <View style={[styles.cardImage, newStyle]} onLayout={(e)=>{this.setState({calc_height: e.nativeEvent.layout.width*9/16});}}>
-        <Image source={this.props.source} resizeMode={["stretch", this.props.resizeMode]} resizeMethod={["resize", this.props.resizeMethod]} style={[styles.imageContainer,  {height: this.state.calc_height}]}>
+        <Image source={this.props.source} resizeMode={this.props.resizeMode || "stretch"} resizeMethod={this.props.resizeMethod || "resize"} style={[styles.imageContainer,  {height: this.state.calc_height}]}>
           {this.props.title!==undefined &&
             <Text style={styles.imageTitleText}>{this.props.title}</Text>
           }

--- a/README.md
+++ b/README.md
@@ -21,19 +21,27 @@ import { Card, CardTitle, CardContent, CardAction, CardButton, CardImage } from 
 Then insert the card in your code:
 ```js
 <Card>
-  <CardImage source={{uri: 'http://placehold.it/480x270'}} title="Above all i am here"/>
-  <CardTitle title="This is title" subtitle="This is sub title"/>
-  <CardContent text="Your device will reboot in few seconds once successful, be patient meanwhile"/>
-  <CardAction separator={true} inColumn={false}>
+  <CardImage 
+    source={{uri: 'http://placehold.it/480x270'}} 
+    title="Above all i am here"
+  />
+  <CardTitle 
+    title="This is a title" 
+    subtitle="This is subtitle"
+   />
+  <CardContent text="Your device will reboot in few seconds once successful, be patient meanwhile" />
+  <CardAction 
+    separator={true} 
+    inColumn={false}>
     <CardButton
       onPress={() => {}}
       title="Push"
-      color='blue'
+      color="blue"
     />
     <CardButton
       onPress={() => {}}
       title="Later"
-      color='blue'
+      color="blue"
     />
   </CardAction>
 </Card>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # React-Native-Material-Cards
-A material design card component, customizable and versatile. 
+A material design card component, customizable and versatile.
 
-![Images](http://i.imgur.com/iDym7bI.png) 
+![Images](http://i.imgur.com/iDym7bI.png)
 
 See [Google Material Design](https://material.io/guidelines/components/cards.html) for more info on Cards.
 
@@ -13,18 +13,18 @@ npm install --save react-native-material-cards
 
 ## Basic Usage
 
+Import the components like so:  
 ```javascript
 import { Card, CardTitle, CardContent, CardAction, CardButton, CardImage } from 'react-native-material-cards'
 ```
 
-## Code
-
+Then insert the card in your code:
 ```js
 <Card>
   <CardImage source={{uri: 'http://placehold.it/480x270'}} title="Above all i am here"/>
   <CardTitle title="This is title" subtitle="This is sub title"/>
   <CardContent text="Your device will reboot in few seconds once successful, be patient meanwhile"/>
-  <CardAction seperator={true} inColumn={false}>
+  <CardAction separator={true} inColumn={false}>
     <CardButton
       onPress={() => {}}
       title="Push"
@@ -38,52 +38,53 @@ import { Card, CardTitle, CardContent, CardAction, CardButton, CardImage } from 
   </CardAction>
 </Card>
 ```
+
 ## Card Component Options
 | Prop        | Type           | Effect  | Default Value |
 | ------------- |-------------| -----| -----|
-| isDark | boolean | If the card background dark, requiring light text color, this passes isDark true to all children sub-components | true |
-| mediaSource | object | The image to show in background of card, with content overlayed, passed to Image's source prop | undefined |
-| avatarSource | object | The avatar image to be shown in card's content or header section, whichever comes first, passed to Image's source prop | undefined |
-| style | object | The  style object to be merged with default style | undefined |
+| `isDark` | `boolean` | If the card background is dark, sets a light text color, this prop is passed to all child components | `true` |
+| `mediaSource` | `object` | The image to show in background of a card, with content overlayed, passed to Image's `source` prop | `undefined` |
+| `avatarSource` | `object` | The avatar image to be shown in the card's content or header section, whichever comes first, passed to Image's `source` prop | `undefined` |
+| `style` | `object` | The style object to be merged with the default style | `undefined` |
 
 ## CardTitle Component Options
 | Prop        | Type           | Effect  | Default Value |
 | ------------- |-------------| -----| -----|
-| title | string | The title text | undefined |
-| subtitle | string | The subtitle text | undefined |
-| subtitleAbove | boolean | If the subtitle is to be shown above title | false |
-| avatarSource | object | The avatar image to be shown, passed to Image's source prop | undefined |
-| style | color | The  style object to be merged with default style | undefined |
+| `title` | `string` | The title text | `undefined` |
+| `subtitle` | `string` | The subtitle text | `undefined` |
+| `subtitleAbove` | `boolean` | Whether the subtitle should be shown above the title | `false` |
+| `avatarSource` | `object` | The avatar image to be shown, passed to Image's `source` prop | `undefined` |
+| `style` | `object` | The style object to be merged with the default style | `undefined` |
 
 ## CardContent Component Options
 | Prop        | Type           | Effect  | Default Value |
 | ------------- |-------------| -----| -----|
-| text | string | The content text | undefined |
-| avatarSource | object | The avatar image to be shown, passed to Image's source prop | undefined |
-| style | color | The  style object to be merged with default style | undefined |
+| `text` | `string` | The content text | `undefined` |
+| `avatarSource` | `object` | The avatar image to be shown, passed to Image's `source` prop | `undefined` |
+| `style` | `object` | The style object to be merged with the default style | `undefined` |
 
 ## CardImage Component Options
 | Prop        | Type           | Effect  | Default Value |
 | ------------- |-------------| -----| -----|
-| source | object | The image to be shown, passed to Image's source prop | undefined |
-| style | color | The  style object to be merged with default style | undefined |
-| resizeMode | string | Determines how to resize the image when the frame doesn't match the raw image dimensions | stretch |
-| resizeMethod | string | Resize the image when the image's dimensions differ from the image view's dimensions. | resize |
+| `source` | `object` | The image to be shown, passed to Image's `source` prop | `undefined` |
+| `style` | `object` | The style object to be merged with the default style | `undefined` |
+| `resizeMode` | `string` | Determines how to resize the image when the frame doesn't match the raw image dimensions | `stretch` |
+| `resizeMethod` | `string` | Resize the image when the image's dimensions differ from the image view's dimensions. | `resize` |
 
 ## CardAction Component Options
 | Prop        | Type           | Effect  | Default Value |
 | ------------- |-------------| -----| -----|
-| seperator | boolean | If separator is to be shown | true |
-| inColumn | boolean | If buttons are to be in column | false |
-| style | color | The  style object to be merged with default style | undefined |
+| `separator` | `boolean` | Whether a separator should be shown | `true` |
+| `inColumn` | `boolean` | Whether the buttons should be stacked in a column | `false` |
+| `style` | `object` | The style object to be merged with the default style | `undefined` |
 
 ## CardButton Component Options
 | Prop        | Type           | Effect  | Default Value |
 | ------------- |-------------| -----| -----|
-| title | string | The button's text | undefined |
-| color | string | The color of button text | 'orange' |
-| onPress | function | The function to be called when button is pressed | noop |
-| style | color | The  style object to be merged with default style | undefined |
+| `title` | `string` | The button's text | `undefined` |
+| `color` | `string` | The color of button text | `orange` |
+| `onPress` | `function` | The function to be called when button is pressed | `noop` (defined in [`src/utils`](https://github.com/SiDevesh/React-Native-Material-Cards/blob/master/src/utils/index.js)) |
+| `style` | `object` | The style object to be merged with the default style | `undefined` |
 
 ### ToDo
 * Add cards with side media

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "url": "https://github.com/SiDevesh/React-Native-Material-Cards/issues"
   },
   "homepage": "https://github.com/SiDevesh/React-Native-Material-Cards#readme",
+  "dependencies": {
+    "prop-types": "^15.5.10"
+  },
   "devDependencies": {
     "babel-eslint": "^7.2.3",
     "eslint": "^3.19.0",
@@ -35,7 +38,7 @@
     "eslint-plugin-react": "^7.0.0"
   },
   "peerDependencies": {
-    "react": ">=15.3.1",
+    "react": ">=15.3.1 || >=16.0.0-beta.5",
     "react-native": "*"
   }
 }

--- a/src/Touchable.js
+++ b/src/Touchable.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import {
   View,
   TouchableOpacity,


### PR DESCRIPTION
This is to correct the issue with React v15.5+. The `PropTypes` is no longer available and has been moved to a separate library, [`prop-types`](https://www.npmjs.com/package/prop-types). This pull request adds it as a dependency and corrects the import in `src/Touchable.js`