### PR TITLE
Upgrade to ImageBackground

### DIFF
--- a/CardImage.js
+++ b/CardImage.js
@@ -17,11 +17,10 @@ export default class CardImage extends Component {
     const newStyle = this.props.style || {};
     return (
       <View style={[styles.cardImage, newStyle]} onLayout={(e)=>{this.setState({calc_height: e.nativeEvent.layout.width*9/16});}}>
-        <Image source={this.props.source} resizeMode={this.props.resizeMode || "stretch"} resizeMethod={this.props.resizeMethod || "resize"} style={[styles.imageContainer,  {height: this.state.calc_height}]}>
+        <Image source={this.props.source} resizeMode={this.props.resizeMode || "stretch"} resizeMethod={this.props.resizeMethod || "resize"} style={[styles.imageContainer,  {height: this.state.calc_height}]}/>
           {this.props.title!==undefined &&
             <Text style={styles.imageTitleText}>{this.props.title}</Text>
           }
-        </Image>
       </View>
     );
   }

--- a/CardImage.js
+++ b/CardImage.js
@@ -3,7 +3,7 @@ import {
   StyleSheet,
   Text,
   View,
-  Image
+  ImageBackground
 } from 'react-native';
 
 export default class CardImage extends Component {
@@ -17,11 +17,11 @@ export default class CardImage extends Component {
     const newStyle = this.props.style || {};
     return (
       <View style={[styles.cardImage, newStyle]} onLayout={(e)=>{this.setState({calc_height: e.nativeEvent.layout.width*9/16});}}>
-        <Image source={this.props.source} resizeMode={this.props.resizeMode || "stretch"} resizeMethod={this.props.resizeMethod || "resize"} style={[styles.imageContainer,  {height: this.state.calc_height}]}>
+        <ImageBackground source={this.props.source} resizeMode={this.props.resizeMode || "stretch"} resizeMethod={this.props.resizeMethod || "resize"} style={[styles.imageContainer,  {height: this.state.calc_height}]}>
           {this.props.title!==undefined &&
             <Text style={styles.imageTitleText}>{this.props.title}</Text>
           }
-        </Image>
+          </ImageBackground>
       </View>
     );
   }

--- a/CardTitle.js
+++ b/CardTitle.js
@@ -93,7 +93,7 @@ const styles = StyleSheet.create({
   avatarStyle: {
     width: 40,
     height: 40,
-    borderRadius: 150,
+    borderRadius: 20,
     marginRight: 16
   }
 });

--- a/src/Touchable.js
+++ b/src/Touchable.js
@@ -40,7 +40,7 @@ const Touchable = ({ onPress, style, children }) => {
 
 Touchable.propTypes = {
   onPress: PropTypes.func.isRequired,
-  style: View.propTypes.style,
+  style: ViewPropTypes.style,
   children: PropTypes.node.isRequired,
 };
 

--- a/src/Touchable.js
+++ b/src/Touchable.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  View,
+  ViewPropTypes,
   TouchableOpacity,
   TouchableNativeFeedback,
 } from 'react-native';


### PR DESCRIPTION
Since react-native 0.50 Image is not allowed to have children anymore.
The newly created ImageBackground component of react-native comes to help.

This fix enables the users to use React-Native-Material-Cards on react-native >=0.50