### PR TITLE
FIX: Style - avatarSource Image not visible

### DIFF
--- a/CardTitle.js
+++ b/CardTitle.js
@@ -93,7 +93,7 @@ const styles = StyleSheet.create({
   avatarStyle: {
     width: 40,
     height: 40,
-    borderRadius: 150,
+    borderRadius: 20,
     marginRight: 16
   }
 });


### PR DESCRIPTION
The borderRadius of 150 on a 40x40 size image made it invisible.
borderRadius of 20 creates a circular image