### PR TITLE
singleLineTitle property for CardImage

### DIFF
--- a/CardImage.js
+++ b/CardImage.js
@@ -19,7 +19,10 @@ export default class CardImage extends Component {
       <View style={[styles.cardImage, newStyle]} onLayout={(e)=>{this.setState({calc_height: e.nativeEvent.layout.width*9/16});}}>
 
         <ImageBackground source={this.props.source} resizeMode={this.props.resizeMode || "stretch"} resizeMethod={this.props.resizeMethod || "resize"} style={[styles.imageContainer,  {height: this.state.calc_height}]}>
-          {this.props.title!==undefined &&
+          {this.props.title!==undefined && this.props.singleLineTitle == true &&
+            <Text numberOfLines={1} style={styles.imageTitleText}>{this.props.title}</Text>
+          }
+          {this.props.title!==undefined && (this.props.singleLineTitle == false || this.props.singleLineTitle === undefined) &&
             <Text style={styles.imageTitleText}>{this.props.title}</Text>
           }
           </ImageBackground>

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Then insert the card in your code:
 | `style` | `object` | The style object to be merged with the default style | `undefined` |
 | `resizeMode` | `string` | Determines how to resize the image when the frame doesn't match the raw image dimensions | `stretch` |
 | `resizeMethod` | `string` | Resize the image when the image's dimensions differ from the image view's dimensions. | `resize` |
+| `singleLineTitle` | `boolean` | Set to true if you want the title to be one line, redacted with ellipses | `undefined` |
 
 ## CardAction Component Options
 | Prop        | Type           | Effect  | Default Value |


### PR DESCRIPTION
For small cards with images, I don't want multi-line text for an image title because it covers too much of the card image. Let's provide support for `singleLineTitle={true}` which replaces overflowing text with ellipses. These changes worked for me.