### PR TITLE
Made card itself clickable when onPress is passed

### DIFF
--- a/Card.js
+++ b/Card.js
@@ -6,6 +6,7 @@ import {
   Image,
   ImageBackground
 } from 'react-native';
+import { Touchable } from './src';
 
 export default class Card extends Component {
 
@@ -120,6 +121,17 @@ export default class Card extends Component {
             {this.renderChildren()}
           </View>
         </ImageBackground>
+      );
+    }
+    else if (this.props.onPress) {
+      return (
+        <Touchable
+          style={[styles.container, styles.card, newStyle]}
+          onPress={this.props.onPress}
+          useForeground={true}
+        >
+          {this.renderChildren()}
+        </Touchable>
       );
     }
     else {

--- a/src/Touchable.js
+++ b/src/Touchable.js
@@ -12,12 +12,13 @@ import {
   noop,
 } from './utils';
 
-const Touchable = ({ onPress, style, children }) => {
+const Touchable = ({ onPress, style, children, useForeground }) => {
   if (IS_ANDROID && !IS_LT_LOLLIPOP) {
     return (
       <TouchableNativeFeedback
         background={TouchableNativeFeedback.SelectableBackground()}
         onPress={onPress}
+        useForeground={useForeground}
       >
         <View
           style={style}


### PR DESCRIPTION
I needed the entire card to be clickable and in my opinion warpping the card in `TouchableOpacity` (#19) doesn't feel right (at least on android). Also wrapping the card in `TouchableNativeFeedback` did not work, it didn't even trigger the onPress.

With this patch if you pass an `onPress` prop to the card it will use the internal `Touchable` component instead of a normal view. I also added `useForeground` to `Touchable` because that looks nicer if you have an image in the card. And you probably shouldn't have a clickable card with buttons so I didn't test how this looks. Also I didn't implement it for cards with a background image.

This is how it looks on android:

![feature-clickable-card](https://user-images.githubusercontent.com/32217236/52438209-1059ad00-2b19-11e9-910f-b5131acb95d0.gif)

**Note: I haven't tested this extensively but it works for my usecase.** I will try to test if I have more time.