### PR TITLE
Added prop to replace the image (background) component of CardImage

### DIFF
--- a/CardImage.js
+++ b/CardImage.js
@@ -3,29 +3,36 @@ import {
   StyleSheet,
   Text,
   View,
-  ImageBackground
+  Image
 } from 'react-native';
 
 export default class CardImage extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      calc_height: 0
+      calc_height: 0,
+      componentWidth: 350,
+      componentHeight: 194
     }
   }
   render () {
     const newStyle = this.props.style || {};
+    const Component = this.props.component || Image;
+
     return (
       <View style={[styles.cardImage, newStyle]} onLayout={(e)=>{this.setState({calc_height: e.nativeEvent.layout.width*9/16});}}>
 
-        <ImageBackground source={this.props.source} resizeMode={this.props.resizeMode || "stretch"} resizeMethod={this.props.resizeMethod || "resize"} style={[styles.imageContainer,  {height: this.state.calc_height}]}>
+        <View style={[styles.imageContainer, {height: this.props.imageHeight || this.state.calc_height}]} onLayout={(e) => {this.setState({componentHeight: e.nativeEvent.layout.height, componentWidth: e.nativeEvent.layout.width});}}>
+          <Component source={this.props.source} resizeMethod={this.props.resizeMethod || "resize"} style={[StyleSheet.absoluteFill, { width: this.props.imageWidth || this.state.componentWidth, height: this.props.imageHeight || this.state.componentHeight }, this.props.imageStyle]} />
+        </View>
+        <View styles={styles.imageContainer}>
           {this.props.title!==undefined && this.props.singleLineTitle == true &&
             <Text numberOfLines={1} style={styles.imageTitleText}>{this.props.title}</Text>
           }
           {this.props.title!==undefined && (this.props.singleLineTitle == false || this.props.singleLineTitle === undefined) &&
             <Text style={styles.imageTitleText}>{this.props.title}</Text>
           }
-          </ImageBackground>
+        </View>
 
       </View>
     );
@@ -40,16 +47,21 @@ const styles = StyleSheet.create({
     alignSelf: 'stretch',
     marginBottom: 16,
     justifyContent: 'center',
-    alignItems: 'stretch'
+    alignItems: 'stretch',
+    overflow: "hidden"
   },
   imageContainer: {
+    position: "absolute",
+    top: 0,
+    left: 0,
     flex: 1,
     flexDirection: 'column',
     paddingRight: 16,
     paddingLeft: 16,
     paddingBottom: 16,
     paddingTop: 16,
-    justifyContent: 'flex-end'
+    justifyContent: 'flex-end',
+    width: "100%"
   },
   imageTitleText: {
     fontSize: 24,

--- a/CardImage.js
+++ b/CardImage.js
@@ -25,14 +25,13 @@ export default class CardImage extends Component {
         <View style={[styles.imageContainer, {height: this.props.imageHeight || this.state.calc_height}]} onLayout={(e) => {this.setState({componentHeight: e.nativeEvent.layout.height, componentWidth: e.nativeEvent.layout.width});}}>
           <Component source={this.props.source} resizeMethod={this.props.resizeMethod || "resize"} style={[StyleSheet.absoluteFill, { width: this.props.imageWidth || this.state.componentWidth, height: this.props.imageHeight || this.state.componentHeight }, this.props.imageStyle]} />
         </View>
-        <View styles={styles.imageContainer}>
-          {this.props.title!==undefined && this.props.singleLineTitle == true &&
-            <Text numberOfLines={1} style={styles.imageTitleText}>{this.props.title}</Text>
-          }
-          {this.props.title!==undefined && (this.props.singleLineTitle == false || this.props.singleLineTitle === undefined) &&
-            <Text style={styles.imageTitleText}>{this.props.title}</Text>
-          }
-        </View>
+
+        {this.props.title!==undefined && this.props.singleLineTitle == true &&
+          <Text numberOfLines={1} style={styles.imageTitleText}>{this.props.title}</Text>
+        }
+        {this.props.title!==undefined && (this.props.singleLineTitle == false || this.props.singleLineTitle === undefined) &&
+          <Text style={styles.imageTitleText}>{this.props.title}</Text>
+        }
 
       </View>
     );
@@ -46,9 +45,8 @@ const styles = StyleSheet.create({
     backgroundColor: 'grey',
     alignSelf: 'stretch',
     marginBottom: 16,
-    justifyContent: 'center',
-    alignItems: 'stretch',
-    overflow: "hidden"
+    alignItems: 'flex-end',
+    overflow: "hidden",
   },
   imageContainer: {
     position: "absolute",
@@ -56,15 +54,15 @@ const styles = StyleSheet.create({
     left: 0,
     flex: 1,
     flexDirection: 'column',
-    paddingRight: 16,
-    paddingLeft: 16,
-    paddingBottom: 16,
-    paddingTop: 16,
     justifyContent: 'flex-end',
     width: "100%"
   },
   imageTitleText: {
     fontSize: 24,
-    color: 'rgba(255 ,255 ,255 , 0.87)'
+    color: 'rgba(255 ,255 ,255 , 0.87)',
+    paddingRight: 16,
+    paddingLeft: 16,
+    paddingBottom: 16,
+    paddingTop: 16,
   }
 });


### PR DESCRIPTION
Motivation: I wanted to use react-native-image-progress for the image.

I replaced ImageBackground with the custom component (or Image as fallback).To make this possible (since not all image-like components can contain children) I wrapped the title and subtitle in a separate view and positioned them absolute on top of the image.

Note: This also fixes a problem where the image ignores the borderRadius of the card.

**Note: I haven't tested this extensively but it works for my use case (and also with a title)**

![screenshot_1549734263](https://user-images.githubusercontent.com/32217236/52524211-de705400-2c9a-11e9-8212-9b020aa482c2.png)
